### PR TITLE
Added extra side note for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ package manager (`apt-get install npm` for Debian), or see the following section
 titled “Node.js” for more details.
 
 If you get a `gyp ERR! stack Error: EACCES: permission denied` error when installing, try the following command instead:
+Side note: For example on Ubuntu 20.04 there are no errors while installing but nyuu crashes when ran for the first time, this solution might also fix that.
 
 ```
 npm install -g nyuu --unsafe-perm


### PR DESCRIPTION
@animetosho like I mentioned in #76 I didn't get an error while running `npm install` but after running nyuu for the first time it just crashes, today on a fresh ubuntu 20.04 I just tried again wondering if the same thing would happen. And again `npm install` went fine, but it wouldn't start. So added this as side note in documentation :)