### PR TITLE
fix: build-dev-win32.yml

### DIFF
--- a/.github/workflows/build-dev-win32.yml
+++ b/.github/workflows/build-dev-win32.yml
@@ -11,7 +11,7 @@ jobs:
       BUILD_LOGLEVEL: verbose
     steps:
       - uses: ilammy/setup-nasm@v1
-      - uses: actions/setup-python@v3
+      - uses: MatteoH2O1999/setup-python@v1 # https://github.com/actions/setup-python/issues/672
         with:
           python-version: '2.7'
       - uses: actions/checkout@v3


### PR DESCRIPTION
[actions/setup-python](https://github.com/actions/setup-python) dropped support for Python 2.7.x (see https://github.com/actions/setup-python/issues/672)
[MatteoH2O1999/setup-python](https://github.com/MatteoH2O1999/setup-python) adds support for deprecated versions back