### PR TITLE
Fix trivial bugs and typos

### DIFF
--- a/cli/arg_parser.js
+++ b/cli/arg_parser.js
@@ -425,3 +425,4 @@ var parseObject = function(config, opts) {
 // export some useful parsing functions
 module.exports.parseSize = parseSize;
 module.exports.parseTime = parseTime;
+module.exports.parseObject = parseObject;

--- a/cli/arg_parser.js
+++ b/cli/arg_parser.js
@@ -415,7 +415,7 @@ var parseObject = function(config, opts) {
 	// handle defaults
 	for(var k in opts) {
 		var o = opts[k];
-		if(o.default && !(k in ret))
+		if(o.default !== undefined && !(k in ret))
 			ret[k] = o.default;
 	}
 	

--- a/cli/arg_parser.js
+++ b/cli/arg_parser.js
@@ -307,19 +307,21 @@ var parseObject = function(config, opts) {
 		// pre-conversion for strings
 		if(typeof v === 'string') {
 			switch(opt.type) {
-				case 'bool':
-					switch(v.toLowerCase()) {
-						case 'true':
-						case '1':
-							v = true;
-							break;
-						case 'false':
-						case '0':
-						case '':
-							v = false;
-							break;
-					}
-					throw new Error('Invalid value specified for `' + k + '`');
+			case 'bool':
+				switch(v.toLowerCase()) {
+					case 'true':
+					case '1':
+						v = true;
+						break;
+					case 'false':
+					case '0':
+					case '':
+						v = false;
+						break;
+					default:
+						throw new Error('Invalid value specified for `' + k + '`');
+				}
+				break;
 				
 				case '-int':
 				case 'int':

--- a/cli/progrec.js
+++ b/cli/progrec.js
@@ -11,7 +11,7 @@ module.exports.prototype = {
 		this.samples.push(num);
 		var len = this.samples.length;
 		if(len > this.size
-		|| (this.maxNum && len > 2 && this.samples[len-1] - this.samples[1] >= maxNum))
+		|| (this.maxNum && len > 2 && this.samples[len-1] - this.samples[1] >= this.maxNum))
 			this.samples.shift();
 	},
 	count: function() {

--- a/lib/filewritestream.js
+++ b/lib/filewritestream.js
@@ -46,7 +46,7 @@ DeferredFileWriteStream.prototype.end = function(chunk, encoding, cb) {
 	}
 	if(chunk) {
 		var buf = toBuffer(chunk, encoding || this.opts.encoding);
-		this.bytesWritten = buf.length;
+		this.bytesWritten += buf.length;
 		this.buffers.push(buf);
 	}
 	var self = this;

--- a/lib/throttlequeue.js
+++ b/lib/throttlequeue.js
@@ -88,7 +88,7 @@ module.exports.prototype = {
 		if(waitTime <= 0) // in case this happens
 			setImmediate(this.onTimeout);
 		else
-			this.timer = Timer('thottle', this.onTimeout, waitTime);
+			this.timer = Timer('throttle', this.onTimeout, waitTime);
 	},
 	
 	// TODO: support dynamically adjusting limits

--- a/lib/uploadmgr.js
+++ b/lib/uploadmgr.js
@@ -191,10 +191,10 @@ UploadManager.prototype = {
 				var nzb = this.opts.nzb(file.num, collectionCounts[file.collection], file.name, file.size, 1, Math.max(1, Math.ceil(file.size / this.articleSize)));
 				if(nzb) {
 					if(!Array.isArray(nzb))
-						throw new Error('Invalid NZB specification supplied for file: ' + fileName);
-					if(!this.nzbs[nzb[0]]) {
-						if(nzb.length != 2 || typeof nzb[1] != 'object')
-							throw new Error('Invalid NZB specification supplied for file: ' + fileName);
+throw new Error('Invalid NZB specification supplied for file: ' + filename);
+				if(!this.nzbs[nzb[0]]) {
+					if(nzb.length != 2 || typeof nzb[1] != 'object')
+						throw new Error('Invalid NZB specification supplied for file: ' + filename);
 						if(nzb[1].writeTo === null || nzb[1].writeTo === undefined)
 							continue; // assume user intended to not write any output (consistent with default setup)
 						this.nzbs[nzb[0]] = {

--- a/lib/uploadmgr.js
+++ b/lib/uploadmgr.js
@@ -191,7 +191,7 @@ UploadManager.prototype = {
 				var nzb = this.opts.nzb(file.num, collectionCounts[file.collection], file.name, file.size, 1, Math.max(1, Math.ceil(file.size / this.articleSize)));
 				if(nzb) {
 					if(!Array.isArray(nzb))
-throw new Error('Invalid NZB specification supplied for file: ' + filename);
+						throw new Error('Invalid NZB specification supplied for file: ' + filename);
 				if(!this.nzbs[nzb[0]]) {
 					if(nzb.length != 2 || typeof nzb[1] != 'object')
 						throw new Error('Invalid NZB specification supplied for file: ' + filename);

--- a/test/arg_parser.js
+++ b/test/arg_parser.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var assert = require("assert");
+var argParser = require('../cli/arg_parser');
+
+describe('Argument Parser', function() {
+
+	describe('parseObject bool handling', function() {
+		var opts = {
+			verbose: {type: 'bool'}
+		};
+
+		it('should parse "true" as true', function() {
+			assert.strictEqual(argParser.parseObject({verbose: 'true'}, opts).verbose, true);
+		});
+
+		it('should parse "1" as true', function() {
+			assert.strictEqual(argParser.parseObject({verbose: '1'}, opts).verbose, true);
+		});
+
+		it('should parse "false" as false', function() {
+			assert.strictEqual(argParser.parseObject({verbose: 'false'}, opts).verbose, false);
+		});
+
+		it('should parse "0" as false', function() {
+			assert.strictEqual(argParser.parseObject({verbose: '0'}, opts).verbose, false);
+		});
+
+		it('should parse "" as false', function() {
+			assert.strictEqual(argParser.parseObject({verbose: ''}, opts).verbose, false);
+		});
+
+		it('should reject invalid bool strings', function() {
+			assert.throws(function() {
+				argParser.parseObject({verbose: 'yes'}, opts);
+			}, /Invalid value/);
+		});
+
+		it('should reject "no" as bool', function() {
+			assert.throws(function() {
+				argParser.parseObject({verbose: 'no'}, opts);
+			}, /Invalid value/);
+		});
+	});
+
+	describe('parseObject defaults', function() {
+		it('should apply default of 0', function() {
+			var opts = {
+				count: {type: 'int', default: 0}
+			};
+			assert.strictEqual(argParser.parseObject({}, opts).count, 0);
+		});
+
+		it('should apply default of false', function() {
+			var opts = {
+				flag: {type: 'bool', default: false}
+			};
+			assert.strictEqual(argParser.parseObject({}, opts).flag, false);
+		});
+
+		it('should apply default of empty string', function() {
+			var opts = {
+				name: {type: 'string', default: ''}
+			};
+			assert.strictEqual(argParser.parseObject({}, opts).name, '');
+		});
+
+		it('should not override provided value', function() {
+			var opts = {
+				count: {type: 'int', default: 0}
+			};
+			assert.strictEqual(argParser.parseObject({count: '5'}, opts).count, 5);
+		});
+	});
+
+});

--- a/test/filewritestream.js
+++ b/test/filewritestream.js
@@ -80,3 +80,26 @@ var target = path.join(process.env.TMP || process.env.TEMP || '.', 'fwstream');
 		
 	});
 });
+
+describe('DeferredWriteStream bytesWritten', function() {
+	it('should accumulate bytesWritten across write and end', function(done) {
+		try { fs.unlinkSync(target); } catch(x) {}
+		
+		var stream = fwstream.createDeferredWriteStream(target);
+		stream.on('open', function() {
+			stream.write('abc', function() {
+				assert.equal(stream.bytesWritten, 3);
+				stream.end('defg', function() {
+					assert.equal(stream.bytesWritten, 7);
+					setTimeout(function() {
+						fs.unlinkSync(target);
+						done();
+					}, 200);
+				});
+			});
+		});
+		stream.on('close', function() {
+			assert(fs.existsSync(target));
+		});
+	});
+});

--- a/test/progrec.js
+++ b/test/progrec.js
@@ -45,6 +45,19 @@ it('should handle max size', function(done) {
 	done();
 });
 
+it('should evict samples when maxNum difference is exceeded', function(done) {
+	var q = new ProgressRecorder(10, 5);
+	q.add(0);
+	q.add(1);
+	q.add(2);
+	assert.equal(q.count(), 3);
+	q.add(10);
+	assert.equal(q.count(), 3);
+	assert.deepEqual(q.samples, [1, 2, 10]);
+	
+	done();
+});
+
 // TODO: more tests
 
 });


### PR DESCRIPTION
- The error messages at lines 194 and 197 referenced `fileName` (camelCase), but the loop variable is `filename` (lowercase). Under strict mode this would throw a `ReferenceError` instead of showing the intended error message.
- The `add()` prototype method referenced bare `maxNum`, which is a constructor parameter not accessible in the prototype scope.
- `DeferredFileWriteStream.prototype.end()` used `this.bytesWritten = buf.length`, which would reset the count to only the final chunk's length instead of accumulating across all prior `_write()` calls.
- The `throw` statement for invalid boolean strings was positioned *after* the inner switch statement rather than inside a `default:` case. As a result, `parseObject` would reject *every* boolean string value, including valid ones like `"true"` and `"false"`.
- The check `if(o.default && !(k in ret))` treated falsy values (`0`, `false`, `''`) as absent, so defaults like `{type: 'int', default: 0}` would never be applied.
- Timer label `'thottle'` corrected to `'throttle'`.