### PR TITLE
STAT an interrupted article before re-posting it

### DIFF
--- a/bin/nyuu.js
+++ b/bin/nyuu.js
@@ -150,6 +150,11 @@ var servOptMap = {
 		postOnly: true,
 		keyMap: 'postRetryDelay'
 	},
+	'check-before-repost': {
+		type: 'bool',
+		postOnly: true,
+		keyMap: 'checkBeforeRepost'
+	},
 	'post-fail-reconnect': {
 		type: 'bool',
 		postOnly: true,

--- a/config.js
+++ b/config.js
@@ -35,6 +35,7 @@ servers: [
 		retryBadResp: false, // enable retrying if a bad response is received
 		postRetries: 1, // how many times to retry if server returns 441 response to posted article
 		postRetryDelay: 0, // delay post retries (above option) by this many milliseconds
+		checkBeforeRepost: true, // if the connection drops whilst an article is being uploaded, STAT the article after reconnecting and only re-post it if the server doesn't have it (otherwise a lost acknowledgement leaves a duplicate on the server under an ID the NZB never sees)
 		postFailReconnect: false, // treat post failure like a connection-level error; postRetries and postRetryDelay settings are ignored if true
 		errorTeardown: false, // false = gracefully close bad connections, true = forcefully destroy them
 		closeTimeout: 5000, // 5 seconds; wait period before forcefully dropping gracefully closed connections

--- a/help-full.txt
+++ b/help-full.txt
@@ -61,6 +61,14 @@ Upload Server Options:
        --post-retries        Number of post retry attempts in response to 441
                              errors (default 1)
        --post-retry-delay    Delay post retries (default 0s)
+       --check-before-repost If the connection drops whilst an article is being
+                             uploaded, STAT the article after reconnecting and
+                             only re-post it if the server does not have it.
+                             Without this, an acknowledgement lost to the
+                             dropout leaves a duplicate article on the server
+                             under a Message-ID the NZB never records. Enabled
+                             by default; use `--no-check-before-repost` on a
+                             server which refuses STAT on posting connections.
        --post-fail-reconnect Treat posting failures as connection fatal errors.
                              This causes the connection to be reestablished in
                              response to this error (flag option)

--- a/lib/nntp.js
+++ b/lib/nntp.js
@@ -299,7 +299,12 @@ NNTP.prototype = {
 				self.debug('Retrying last request(s)');
 				self._requests = [];
 				reqs.forEach(function(req) {
-					self[req.func](req);
+					// if the connection dropped whilst the article was being uploaded, the server may have accepted it
+					// before we lost the response; ask it before sending the article again under a new Message-ID
+					if(self.opts.checkBeforeRepost && req.func == '__post' && req.type == 'post-upload' && req.errVal)
+						self._resolveLostPost(req);
+					else
+						self[req.func](req);
 				});
 			}
 			cb();
@@ -887,6 +892,23 @@ NNTP.prototype = {
 			else
 				self.__doRequest(req);
 		})();
+	},
+	// A post whose upload was interrupted: STAT the Message-ID we sent it under. If the server has it, the
+	// article was accepted and only the 240 was lost, so report it posted under that ID rather than uploading
+	// a duplicate under a fresh one (which the original ID would then dangle beside, invisible to the NZB).
+	// A STAT the server refuses (posting-only accounts, 480 etc) or answers 430/423 to falls back to re-posting.
+	_resolveLostPost: function(req) {
+		var self = this, msgId = req.errVal;
+		this._doRequest('STAT <' + msgId + '>\r\n', 'stat', [423, 430, 223], function(err, code, info) {
+			if(!err && code == 223) {
+				self.debug('Article ' + msgId + ' had already been accepted before the connection dropped; not re-posting');
+				req.cb(null, 240, '<' + msgId + '> Article received ok');
+				return;
+			}
+			if(err)
+				self.warn('Could not determine whether article ' + msgId + ' was accepted before the connection dropped (' + err.message + '); re-posting it');
+			self.__post(req);
+		});
 	},
 	_doRequest: function(msg, type, validResp, cb) {
 		this.__doRequest(new NNTPReq('__doRequest', msg, type, validResp, cb));

--- a/test/full.js
+++ b/test/full.js
@@ -482,6 +482,63 @@ describe('Nyuu', function() {
 	*/
 });
 
+
+// --- a lost 240: the article must not be posted twice ---
+var fs = require('fs');
+var nzbSegmentIds = function() {
+	var nzb = fs.readFileSync('output.nzb', 'utf8');
+	return (nzb.match(/<segment[^>]*>[^<]*<\/segment>/g) || []).map(function(s) {
+		return s.replace(/^.*>([^<]*)<\/segment>$/, '$1');
+	});
+};
+
+[true, false].forEach(function(checkFirst) {
+	it('should ' + (checkFirst ? 'not duplicate' : 'duplicate (control: old behaviour)') + ' an article whose 240 was lost to a dropout', function(done) {
+		var opts = {
+			server: {
+				postConnections: 1,
+				checkBeforeRepost: checkFirst,
+				requestRetries: 2
+			},
+			check: { tries: 0 }
+		};
+		(function(cb) {
+			var server = testSkel(['help.txt'], opts, function(err) {
+				if(err) return cb(err);
+				server.close(function() {
+					cb(null, server);
+				});
+			});
+			var dropped = false;
+			server.onConnect(function(conn) {
+				var orig = conn._respond;
+				conn._respond = function(code, msg) {
+					// accept the article (it is already stored), then drop the link instead of acknowledging it
+					if(code == 240 && !dropped) {
+						dropped = true;
+						conn.conn.destroy();
+						return;
+					}
+					orig.call(conn, code, msg);
+				};
+			});
+		})(function(err, server) {
+			if(err) return done(err);
+			var ids = Object.keys(server.postIdMap);
+			var segs = nzbSegmentIds();
+			if(checkFirst) {
+				assert.equal(ids.length, 1, 'exactly one article on the server');
+				assert.deepEqual(segs, ids, 'the NZB names the article the server holds');
+			} else {
+				assert.equal(ids.length, 2, 'old behaviour: the article is on the server twice');
+				assert.equal(segs.length, 1);
+				assert.notEqual(ids.indexOf(segs[0]), -1);
+			}
+			done();
+		});
+	});
+});
+
 it('complex test', function(done) {
 	doTest(['lib/', 'help.txt', {
 		name: 'emptyfile',

--- a/test/nntp.js
+++ b/test/nntp.js
@@ -1231,6 +1231,79 @@ it('should resend request if connection lost before response received', function
 	});
 });
 
+[true, false].forEach(function(serverHasIt) {
+	it('should STAT before re-posting if connection drops out during upload (article ' + (serverHasIt ? 'accepted' : 'missing') + ')', function(done) {
+		var server, client;
+		waterfall([
+			setupTest.bind(null, {uploadChunkSize: 1, checkBeforeRepost: true}),
+			function(_server, _client, cb) {
+				server = _server;
+				client = _client;
+				client.connect(cb);
+			},
+			function(cb) {
+				assert.equal(client.state, 'connected');
+				
+				var msg = 'My-Secret: not telling\r\n\r\nNyuu breaks free again!\r\n.\r\n';
+				server.expect('POST\r\n', function() {
+					this.expect(msg, function() {
+						// article fully sent, drop before acknowledging it
+						server.expect('STAT <xxxx>\r\n', function() {
+							if(serverHasIt) {
+								// server has it: no second upload may follow
+								this.respond('223 0 <xxxx> article retrieved - request text separately');
+							} else {
+								this.expect('POST\r\n', function() {
+									this.expect(msg, '240 <new-article> Article received ok');
+									this.respond('340  Send article');
+								});
+								this.respond('430 No article with that message-id');
+							}
+						});
+						setTimeout(function() {
+							server.drop();
+						}, 30);
+					});
+					this.respond('340  Send article');
+				});
+				client.post(new DummyPost(msg), cb);
+			},
+			function(a, cb) {
+				assert.equal(a, serverHasIt ? 'xxxx' : 'new-article');
+				assert.equal(server.connCount, 2);
+				
+				closeTest(client, server, cb);
+			}
+		], done);
+	});
+});
+it('should not STAT if connection drops out before the article is sent', function(done) {
+	var server, client;
+	waterfall([
+		setupTest.bind(null, {checkBeforeRepost: true}),
+		function(_server, _client, cb) {
+			server = _server;
+			client = _client;
+			client.connect(cb);
+		},
+		function(cb) {
+			var msg = 'My-Secret: not telling\r\n\r\nNyuu breaks free again!\r\n.\r\n';
+			server.expect('POST\r\n', function() {
+				server.expect('POST\r\n', function() {
+					this.expect(msg, '240 <new-article> Article received ok');
+					this.respond('340  Send article');
+				});
+				server.drop();
+			});
+			client.post(new DummyPost(msg), cb);
+		},
+		function(a, cb) {
+			assert.equal(a, 'new-article');
+			closeTest(client, server, cb);
+		}
+	], done);
+});
+
 [false, true].forEach(function(reconn) {
 	it('should '+(reconn?'reconnect':'retry')+' on first post failure', function(done) {
 		var server, client;


### PR DESCRIPTION
When the connection drops while an article is being uploaded, `__post`
retries after reconnecting and, unless `--keep-message-id` is set,
re-posts under a freshly randomised Message-ID. If the server had in
fact accepted the article and only the `240` was lost, that leaves two
copies on the server, and the NZB only ever records the second one. The
first is unreachable by anyone holding the NZB and uncancellable by the
poster, who never sees its id.

This change asks first. After the reconnect, a request whose type is
`post-upload` (article data was at least partly sent) is resolved with a
`STAT <id>` on the id it was sent under:

- `223`: the article was accepted; the request completes as posted under
  that id and nothing is re-uploaded.
- `430` / `423`: not there; re-post exactly as before.
- any error (a posting-only account that refuses STAT, a second
  dropout, a timeout): warn and re-post exactly as before.

So the only behaviour that changes is the case that used to produce a
duplicate. It is on by default because the fallback is the old
behaviour, and `--no-check-before-repost` turns it off (config key
`checkBeforeRepost`) for a server where the extra round trip is not
wanted.

A dropout before the article is sent (`post` type, waiting on the 340)
never STATs: there is nothing to ask about.

Tests. Three unit cases in `test/nntp.js` (accepted, missing, and the
drop-before-send case; the helper defaults the option off so the
existing suite's expectations are untouched and the new cases opt in),
and two end-to-end cases in `test/full.js` against the test NNTP
server, where the server stores the article and then destroys the
connection instead of sending the 240:

- with the option on: one article on the server, and the NZB names it;
- with the option off (the old behaviour, kept as a control): the same
  article is on the server twice and the NZB names only the second.

The control case also fails on current master in the same way, which is
the defect. Whole suite: 203 passing (198 on master).