### PR TITLE
README: document posting without an identifying signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,33 @@ If a config file isn't specified, Nyuu will also search the `NYUU_CONFIG`
 environment variable for a default configuration (saving you from needing to
 specify this file on every run, if you set the environment up in your shell).
 
+Posting Without a Signature
+---------------------------
+
+Out of the box, four things in a Nyuu post say who made it and with what:
+
+-   the `From` header, which defaults to your login name at your machine's
+    hostname
+-   the `User-Agent` header, `Nyuu/<version>`
+-   the `Message-ID`, whose default form `<24 random chars>-<unix ms>@nyuu`
+    names the program and carries a per-article millisecond clock
+-   the `Date` header (always sent; a post needs one)
+
+None of these affect whether a post downloads, and all of them are already
+under your control. A configuration which sends none of them looks like this
+on the command line:
+
+    nyuu -H User-Agent -f 'poster <poster@example.invalid>' \
+         --message-id '${rand(32)}@${rand(12)}.invalid' ...
+
+`-H User-Agent` with no value unsets the header. In a JSON config file the
+equivalent keys are `"from"` and `"message-id"`; the `User-Agent` header can
+only be unset from the command line. Together with `--subject`, `--filename`
+and `--yenc-name` templates using `${rand(N)}`, this is everything Nyuu offers
+for a post that carries no identifying text - note that it hides the *poster*,
+not the *content*: yEnc is a reversible transform, so the payload is exactly
+as readable as it ever was.
+
 Planned Features
 ================
 

--- a/config-sample.json
+++ b/config-sample.json
@@ -16,6 +16,8 @@
 "article-size":       "700K",
 "comment":            "",
 "from":               "Snazzy Poster <me@localhost.localdomain>",
+" The default From is your login name at your hostname, and the default Message-ID names Nyuu; see 'Posting Without a Signature' in the README ":0,
+"message-id":         "${rand(32)}@${rand(12)}.invalid",
 "groups":             "alt.binaries.test, alt.binaries.boneless",
 
 " *** Check Options *** ":0,


### PR DESCRIPTION
Docs only. A default Nyuu post carries four things that identify the
poster or the tool, none of which affect whether it downloads:

- `From`: login name at the machine's hostname
- `User-Agent: Nyuu/<version>`
- the Message-ID's `-<unix ms>@nyuu` tail (names the program and carries
  a per-article millisecond clock)
- `Date` (always sent; a post needs one)

Every one of the first three is already removable with existing flags,
but a user has to know that `-H User-Agent` with no value unsets a
header, and that `--message-id` takes the same template tokens as
`--subject`. This adds a "Posting Without a Signature" section to the
README after "Default Configuration" showing the one command line that
does all three, says which of them the JSON config can carry
(`from`, `message-id`; `User-Agent` is command-line only), and is clear
that this hides the poster and not the payload.

`config-sample.json` gains a `message-id` line with the neutral form and
a one-line note pointing at the section.

Checked by running `bin/nyuu.js` against `test/_nntpsrv.js` and reading
the stored headers: the default post carries `From: <login>
<<login>@<hostname>.localdomain>`, `User-Agent: Nyuu/0.4.2` and a
`...-<ms>@nyuu` Message-ID; the command line in the new section leaves
none of the three; the JSON form with `from` and `message-id` leaves
only `User-Agent`, as the text says.

I have not changed any default here. Whether `User-Agent` and the
`@nyuu` host should stay the defaults is a separate question and I have
opened it as a discussion issue (#146) rather than deciding it in a PR.